### PR TITLE
Fix laps assgined to incorrect quali session - 2023/04 HAM,PER

### DIFF
--- a/data/2023/04-Azerbaijan Grand Prix/quali/session_split_fix.json
+++ b/data/2023/04-Azerbaijan Grand Prix/quali/session_split_fix.json
@@ -1,0 +1,410 @@
+[
+  {
+    "object_type": "lap",
+    "foreign_keys": {
+      "year": 2023,
+      "round": 4,
+      "session": "Q1",
+      "car_number": 11
+    },
+    "objects": [
+      {
+        "number": 2,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 103373
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": false
+      },
+      {
+        "number": 3,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 144688
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": false
+      },
+      {
+        "number": 4,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 1128288
+        },
+        "is_deleted": true,
+        "is_entry_fastest_lap": false
+      },
+      {
+        "number": 5,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 780559
+        },
+        "is_deleted": true,
+        "is_entry_fastest_lap": false
+      },
+      {
+        "number": 6,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 101756
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": true
+      },
+      {
+        "number": 7,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 134617
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": false
+      },
+      {
+        "number": 8,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 111913
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": false
+      }
+    ]
+  },
+  {
+    "object_type": "lap",
+    "foreign_keys": {
+      "year": 2023,
+      "round": 4,
+      "session": "Q2",
+      "car_number": 11
+    },
+    "objects": [
+      {
+        "number": 9,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 593591
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": false
+      },
+      {
+        "number": 10,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 101131
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": true
+      },
+      {
+        "number": 11,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 129368
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": false
+      },
+      {
+        "number": 12,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 409596
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": false
+      },
+      {
+        "number": 13,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 110811
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": false
+      }
+    ]
+  },
+  {
+    "object_type": "lap",
+    "foreign_keys": {
+      "year": 2023,
+      "round": 4,
+      "session": "Q3",
+      "car_number": 11
+    },
+    "objects": [
+      {
+        "number": 14,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 574849
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": false
+      },
+      {
+        "number": 15,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 100563
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": false
+      },
+      {
+        "number": 16,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 124534
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": false
+      },
+      {
+        "number": 17,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 249691
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": false
+      },
+      {
+        "number": 18,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 100495
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": true
+      },
+      {
+        "number": 19,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 174810
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": false
+      }
+    ]
+  },
+  {
+    "object_type": "lap",
+    "foreign_keys": {
+      "year": 2023,
+      "round": 4,
+      "session": "Q1",
+      "car_number": 44
+    },
+    "objects": [
+      {
+        "number": 2,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 103676
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": false
+      },
+      {
+        "number": 3,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 132007
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": false
+      },
+      {
+        "number": 4,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 102915
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": false
+      },
+      {
+        "number": 5,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 1112165
+        },
+        "is_deleted": true,
+        "is_entry_fastest_lap": false
+      },
+      {
+        "number": 6,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 780824
+        },
+        "is_deleted": true,
+        "is_entry_fastest_lap": false
+      },
+      {
+        "number": 7,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 102113
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": true
+      },
+      {
+        "number": 8,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 134139
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": false
+      },
+      {
+        "number": 9,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 109888
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": false
+      }
+    ]
+  },
+  {
+    "object_type": "lap",
+    "foreign_keys": {
+      "year": 2023,
+      "round": 4,
+      "session": "Q2",
+      "car_number": 44
+    },
+    "objects": [
+      {
+        "number": 10,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 571805
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": false
+      },
+      {
+        "number": 11,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 102173
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": false
+      },
+      {
+        "number": 12,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 125210
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": false
+      },
+      {
+        "number": 13,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 217234
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": false
+      },
+      {
+        "number": 14,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 101650
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": true
+      },
+      {
+        "number": 15,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 127697
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": false
+      },
+      {
+        "number": 16,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 113413
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": false
+      }
+    ]
+  },
+  {
+    "object_type": "lap",
+    "foreign_keys": {
+      "year": 2023,
+      "round": 4,
+      "session": "Q3",
+      "car_number": 44
+    },
+    "objects": [
+      {
+        "number": 17,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 595034
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": false
+      },
+      {
+        "number": 18,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 101177
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": true
+      },
+      {
+        "number": 19,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 117236
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": false
+      },
+      {
+        "number": 20,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 230098
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": false
+      },
+      {
+        "number": 21,
+        "time": {
+          "_type": "timedelta",
+          "milliseconds": 101276
+        },
+        "is_deleted": false,
+        "is_entry_fastest_lap": false
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This assigns the offending laps to the correct quali session for HAM and PER, xref https://github.com/jolpica/jolpica-f1/issues/286

@jolpica this same issue exists for (almost) all drivers that made it to at least Q2 in this session. Fixing this manually is a bit tedious and I am not entirely sure that I have fully understood this patching stuff here. If you think this is fine, I'd like to merge this and see if the result is as expected. Then I can look into fixing the remaining drivers as well. For the remaining drivers, you don't notice this problem as easily, as their fastest lap times for each session are unaffected by the problem.

Also, there are more offending qualifying sessions. I still have to check how many and how much work it is, to fix them all.