### PR TITLE
Update FP1 starting time for 2026 Miami GP

### DIFF
--- a/data/2026/00-Schedule/calendar.json
+++ b/data/2026/00-Schedule/calendar.json
@@ -452,7 +452,7 @@
       {
         "number": 1,
         "type": "FP1",
-        "timestamp": "2026-05-01T16:30:00Z",
+        "timestamp": "2026-05-01T16:00:00Z",
         "has_time_data": true,
         "timezone": "America/New_York",
         "is_cancelled": false


### PR DESCRIPTION
The FP1 starting time was changed roughly one week before the event.

xref https://github.com/jolpica/jolpica-f1/issues/362