### PR TITLE
Update Miami GP race start time for 2026

### DIFF
--- a/data/2026/00-Schedule/miami_race_time_update.json
+++ b/data/2026/00-Schedule/miami_race_time_update.json
@@ -1,0 +1,19 @@
+[
+  {
+    "object_type": "Session",
+    "foreign_keys": {
+      "year": 2026,
+      "round": 6
+    },
+    "objects": [
+      {
+        "number": 9,
+        "type": "R",
+        "timestamp": "2026-05-03T17:00:00Z",
+        "has_time_data": true,
+        "timezone": "America/New_York",
+        "is_cancelled": false
+      }
+    ]
+  }
+]


### PR DESCRIPTION
The 2026 Miami Grand Prix race start time has been updated from 16:00 to 13:00 local time on Sunday, May 3.

Miami is UTC-4, so the race session timestamp is updated from `2026-05-03T20:00:00Z` to `2026-05-03T17:00:00Z`.

Source: FIA Document 64, 2026 Miami Grand Prix Timetable V6, issued 2026-05-02 20:05. The timetable lists Formula 1 Grand Prix at 13:00-15:00 local time.

xref https://github.com/jolpica/jolpica-f1/issues/364

Related context: https://github.com/jolpica/jolpica-f1/issues/362

Fixes jolpica/jolpica-f1#364
Fixes Nicxe/f1_sensor#490